### PR TITLE
Fix undefined behavior

### DIFF
--- a/library/include/borealis/views/applet_frame.hpp
+++ b/library/include/borealis/views/applet_frame.hpp
@@ -21,7 +21,7 @@
 #include <borealis/core/bind.hpp>
 #include <borealis/core/box.hpp>
 #include <borealis/core/event.hpp>
-#include <borealis/views/hint.hpp>
+#include <borealis/views/bottom_bar.hpp>
 #include <borealis/views/image.hpp>
 #include <borealis/views/label.hpp>
 
@@ -74,7 +74,7 @@ class AppletFrame : public Box
 
   private:
     BRLS_BIND(Box, header, "brls/applet_frame/header");
-    BRLS_BIND(Hints, footer, "brls/applet_frame/footer");
+    BRLS_BIND(BottomBar, footer, "brls/applet_frame/footer");
     BRLS_BIND(Label, title, "brls/applet_frame/title_label");
     BRLS_BIND(Image, icon, "brls/applet_frame/title_icon");
     BRLS_BIND(Box, hintBox, "brls/applet_frame/hint_box");


### PR DESCRIPTION
This bug was introduced in this commit: https://github.com/XITRIX/borealis/commit/adaaa44b367a09030269fd4af093fcc4ae3f8bd6

It will cause random error when deleting AppletFrame.
