### PR TITLE
Fix: Memory leak and undefined behavior on RecyclerFrame destruction

### DIFF
--- a/library/include/borealis/views/recycler.hpp
+++ b/library/include/borealis/views/recycler.hpp
@@ -154,6 +154,11 @@ class RecyclerDataSource
      * Tells the data source a row is selected.
      */
     virtual void didSelectRowAt(RecyclerFrame* recycler, IndexPath index) { }
+
+    /*
+     * Required for proper class inheritance.
+     */
+    virtual ~RecyclerDataSource() = default;
 };
 
 class RecyclerContentBox : public Box

--- a/library/lib/views/recycler.cpp
+++ b/library/lib/views/recycler.cpp
@@ -205,8 +205,8 @@ RecyclerFrame::RecyclerFrame()
 
 RecyclerFrame::~RecyclerFrame()
 {
-    //    if (this->dataSource)
-    //        delete dataSource;
+    if (this->dataSource)
+        delete dataSource;
 
     for (auto it : queueMap)
     {


### PR DESCRIPTION
`RecyclerFrame` destructor has to calls its `dataSource` member destructor so it avoids memory leak.

Also `RecyclerDataSource` doesn't provide a virtual destructor causing`delete dataSource` to results in undefined behavior (often memory leak).